### PR TITLE
✨ Remove host from api docu

### DIFF
--- a/packages/backend/src/docs/rest-api.yml
+++ b/packages/backend/src/docs/rest-api.yml
@@ -6,7 +6,6 @@ info:
   license:
     name: "GNU AFFERO GENERAL PUBLIC LICENSE"
     url: "https://github.com/tjarbo/discord-moodle-bot/tree/development"
-host: "localhost:4040"
 basePath: "/api"
 tags:
 - name: "Login"


### PR DESCRIPTION
## Description
Removed one line of code containing the host name for the swagger documentation. Closes #96.
The interactive documentation now automatically uses the host that serve the documentation (live test was successfull).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
<!--- Go over all the following points, and put an `x` in all boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Make sure you are requesting to main. Don't request to release branch!
- [x] I have linked the related issue.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
