### PR TITLE
🚸 Allow Discord User Names for WebAuthn

### DIFF
--- a/packages/backend/src/controllers/administrator/administrator.schema.ts
+++ b/packages/backend/src/controllers/administrator/administrator.schema.ts
@@ -25,4 +25,4 @@ export const Administrator: Model<IAdministratorDocument> = model<IAdministrator
 export const administratorUsernameValidationSchema = alternatives().try(
   string().required().min(8).max(64).alphanum(),
   string().required().min(8).max(36).pattern(/^[\w\s]{3,32}#[0-9]{4}$/)
-).description('Username of administrator');
+).required().description('Username of administrator');

--- a/packages/backend/src/controllers/administrator/administrator.schema.ts
+++ b/packages/backend/src/controllers/administrator/administrator.schema.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:ban-types */
 import { Schema, model, Model, Document } from 'mongoose';
 import { IAuthenticatorDocument, authenticatorSchema } from './authenticator.schema';
-import { string } from '@hapi/joi';
+import { string, alternatives } from '@hapi/joi';
 
 export interface IAdministratorDocument extends Document {
   [_id: string]: any;
@@ -22,4 +22,7 @@ const administratorSchema = new Schema({
 
 export const Administrator: Model<IAdministratorDocument> = model<IAdministratorDocument>('Administrator', administratorSchema);
 
-export const administratorUsernameValidationSchema = string().alphanum().required().min(8).max(64).description('Username of administrator');
+export const administratorUsernameValidationSchema = alternatives().try(
+  string().required().min(8).max(64).alphanum(),
+  string().required().min(8).max(36).pattern(/^[\w\s]{3,32}#[0-9]{4}$/)
+).description('Username of administrator');

--- a/packages/backend/tests/administrator.spec.ts
+++ b/packages/backend/tests/administrator.spec.ts
@@ -154,8 +154,8 @@ describe('administrator/index.ts adminAdministratorDeleteRequest', () => {
       },
       {
         // username not alphanumeric
-        prepare: () => { mockRequest.params.username = "test#1234"; },
-        expect: new ApiError(400, '"username" must only contain alpha-numeric characters')
+        prepare: () => { mockRequest.params.username = "test@1234"; },
+        expect: new ApiError(400, '"username" does not match any of the allowed types')
     }];
 
     for (let index = 0; index < tests.length; index++) {

--- a/packages/backend/tests/auth.spec.ts
+++ b/packages/backend/tests/auth.spec.ts
@@ -75,9 +75,9 @@ describe('auth/index.ts authAttestationGetRequest', () => {
         expect: new ApiError(400, '"username" is required')
       },
       {
-        // username not alphanumeric
-        prepare: () => { mockRequest.query.username = "test#1234"; },
-        expect: new ApiError(400, '"username" must only contain alpha-numeric characters')
+        // username not alphanumeric or discord username
+        prepare: () => { mockRequest.query.username = "test@1234"; },
+        expect: new ApiError(400, '"username" does not match any of the allowed types')
       },
       {
         // token not provided
@@ -201,9 +201,9 @@ describe('auth/index.ts authAttestationPostRequest', () => {
         expect: new ApiError(400, '"username" is required')
       },
       {
-        // username not alphanumeric
-        prepare: () => { mockRequest.body.username = "test#1234"; },
-        expect: new ApiError(400, '"username" must only contain alpha-numeric characters')
+        // username not alphanumeric or discord username
+        prepare: () => { mockRequest.body.username = "test@1234"; },
+        expect: new ApiError(400, '"username" does not match any of the allowed types')
       },
       {
         // token not provided
@@ -364,9 +364,9 @@ describe('auth/index.ts authAssertionGetRequest', () => {
         expect: new ApiError(400, '"username" is required')
       },
       {
-        // username not alphanumeric
-        prepare: () => { mockRequest.query.username = "test#1234"; },
-        expect: new ApiError(400, '"username" must only contain alpha-numeric characters')
+        // username not alphanumeric or discord username
+        prepare: () => { mockRequest.query.username = "test@1234"; },
+        expect: new ApiError(400, '"username" does not match any of the allowed types')
       },
     ]
     
@@ -485,9 +485,9 @@ describe('auth/index.ts authAssertionPostRequest', () => {
         expect: new ApiError(400, '"username" is required')
       },
       {
-        // username not alphanumeric
-        prepare: () => { mockRequest.body.username = "test#1234"; },
-        expect: new ApiError(400, '"username" must only contain alpha-numeric characters')
+        // username not alphanumeric or Discord
+        prepare: () => { mockRequest.body.username = "test@1234"; },
+        expect: new ApiError(400, '"username" does not match any of the allowed types')
       },
       {
         // assertionResponse must be provided

--- a/packages/frontend/src/components/UsernameInputField.vue
+++ b/packages/frontend/src/components/UsernameInputField.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="has-text-left">
+    <b-field
+      :type="errorDescription !== '' ? 'is-danger' : ''"
+      :message="errorDescription">
+      <b-input
+        type="text"
+        size="is-large"
+        v-model="$v.username.$model"
+        @input="onInput"
+        :placeholder="$t('components.usernameInputField.placeholder')"
+      >
+      </b-input>
+    </b-field>
+  </div>
+</template>
+
+<script>
+import {
+  required, alphaNum, minLength, maxLength, or, helpers,
+} from 'vuelidate/lib/validators';
+
+const discordUsername = helpers.regex('discordusername', /^.{3,32}#[0-9]{4}$/);
+
+export default {
+  name: 'UsernameInputField',
+  computed: {
+    errorDescription() {
+      if (!this.$v.$dirty) return '';
+      let result;
+
+      switch (false) {
+        case this.$v.username.required:
+          result = this.$t('general.validationErrors.required');
+          break;
+
+        case this.$v.username.minLength:
+          result = this.$t('general.validationErrors.minLength', [8]);
+          break;
+
+        case this.$v.username.maxLength:
+          result = this.$t('general.validationErrors.maxLength', [32]);
+          break;
+
+        case this.$v.username.or:
+          result = this.$t('components.usernameInputField.validationErrors.alphaNumOrDiscord');
+          break;
+
+        default:
+          break;
+      }
+
+      return result;
+    },
+  },
+  data: () => ({
+    username: '',
+  }),
+  methods: {
+    onInput() {
+      this.$emit('input', this.username, this.$v.$invalid);
+    },
+  },
+  validations: {
+    username: {
+      required,
+      or: or(alphaNum, discordUsername),
+      minLength: minLength(8),
+      maxLength: maxLength(64),
+    },
+  },
+};
+</script>
+
+<style>
+
+</style>

--- a/packages/frontend/src/components/UsernameInputField.vue
+++ b/packages/frontend/src/components/UsernameInputField.vue
@@ -20,7 +20,7 @@ import {
   required, alphaNum, minLength, maxLength, or, helpers,
 } from 'vuelidate/lib/validators';
 
-const discordUsername = helpers.regex('discordusername', /^.{3,32}#[0-9]{4}$/);
+const discordUsername = helpers.regex('discordusername', /^[\w\s]{3,32}#[0-9]{4}$/);
 
 export default {
   name: 'UsernameInputField',

--- a/packages/frontend/src/components/UsernameInputField.vue
+++ b/packages/frontend/src/components/UsernameInputField.vue
@@ -4,6 +4,7 @@
       :type="errorDescription !== '' ? 'is-danger' : ''"
       :message="errorDescription">
       <b-input
+        id="username"
         type="text"
         size="is-large"
         v-model="$v.username.$model"

--- a/packages/frontend/src/locales/de.json
+++ b/packages/frontend/src/locales/de.json
@@ -104,6 +104,12 @@
     },
     "theNavBar": {
       "logoutButton": "Logout"
+    },
+    "usernameInputField": {
+      "placeholder": "Dein Benutzername",
+      "validationErrors": {
+        "alphaNumOrDiscord": "Nur alphanumerische oder Discord Benutzernamen sind erlaubt"
+      }
     }
   },
   "general": {
@@ -143,6 +149,11 @@
     },
     "update": "Aktualisieren",
     "unknown": "Unbekannt",
+    "validationErrors": {
+      "required": "Bitte fülle dieses Feld aus",
+      "minLength": "Mindestens {0} Zeichen sind erforderlich",
+      "maxLength": "Es dürfen höhstens {0} Zeichen sein"
+    },
     "value": "Wert"
   },
   "layouts": {
@@ -162,8 +173,7 @@
         "loginSuccess": "Anmeldung war erfolgreich!"
       },
       "subtitle": "Melde dich an, um fortzufahren!",
-      "switchViewText": "Du hast einen Token bekommen?",
-      "usernamePlaceholder": "Dein Benutzername"
+      "switchViewText": "Du hast einen Token bekommen?"
     },
     "registration": {
       "notifications": {

--- a/packages/frontend/src/locales/en.json
+++ b/packages/frontend/src/locales/en.json
@@ -104,6 +104,12 @@
     },
     "theNavBar": {
       "logoutButton": "Logout"
+    },
+    "usernameInputField": {
+      "placeholder": "Your username",
+      "validationErrors": {
+        "alphaNumOrDiscord": "Only alphanumeric or discord usernames are allowed"
+      }
     }
   },
   "general": {
@@ -143,6 +149,11 @@
     },
     "update": "Update",
     "unknown": "Unknown",
+    "validationErrors": {
+      "required": "This field is required",
+      "minLength": "Please enter at least {0} characters",
+      "maxLength": "The maximum are {0} characters"
+    },
     "value": "Value"
   },
   "layouts": {
@@ -162,8 +173,7 @@
         "loginSuccess": "Login successful!"
       },
       "subtitle": "Log in to continue!",
-      "switchViewText": "You have received a token?",
-      "usernamePlaceholder": "Your username"
+      "switchViewText": "You have received a token?"
     },
     "registration": {
       "notifications": {

--- a/packages/frontend/src/views/Login.vue
+++ b/packages/frontend/src/views/Login.vue
@@ -19,7 +19,7 @@
           <button
             id="loginSubmitButton"
             class="button is-block is-primary is-large is-fullwidth is-marginless"
-            :disabled="this.form.invalid"
+            :disabled="this.form.isInvalid"
           >
             {{ $t('views.login.loginSubmitButton') }}
           </button>

--- a/packages/frontend/src/views/Login.vue
+++ b/packages/frontend/src/views/Login.vue
@@ -1,9 +1,9 @@
 <template>
   <div id="loginview">
     <authentication-layout
-      @submit="onSubmit"
       title="Fancy Moodle Discord Bot"
       switchViewLink="/registration"
+      @submit="onSubmit"
       :subtitle="$t('views.login.subtitle')"
       :switchViewText="$t('views.login.switchViewText')"
     >
@@ -11,25 +11,15 @@
         :is-full-page="false"
         :active="authGetStatus.pending"
       ></b-loading>
-      <div class="field">
-        <div class="control">
-          <input
-            autofocus
-            class="input is-large"
-            id="username"
-            type="text"
-            v-model="form.username"
-            :placeholder="$t('views.login.usernamePlaceholder')"
-          />
-        </div>
-      </div>
+
+      <username-input-field class="mb-3" @input="onInput"/>
 
       <div class="field">
         <div class="control">
           <button
             id="loginSubmitButton"
             class="button is-block is-primary is-large is-fullwidth is-marginless"
-            :disabled="$v.$invalid"
+            :disabled="this.form.invalid"
           >
             {{ $t('views.login.loginSubmitButton') }}
           </button>
@@ -40,24 +30,31 @@
 </template>
 
 <script>
-import {
-  required, alphaNum, minLength, maxLength,
-} from 'vuelidate/lib/validators';
+
 import { mapGetters } from 'vuex';
 import { startAssertion } from '@simplewebauthn/browser';
-import AuthenticationLayout from '../layouts/AuthenticationLayout.vue';
 import { notifyFailure, notifySuccess } from '../notification';
+import AuthenticationLayout from '../layouts/AuthenticationLayout.vue';
+import UsernameInputField from '../components/UsernameInputField.vue';
 
 export default {
   name: 'LoginView',
-  components: { AuthenticationLayout },
+  components: { AuthenticationLayout, UsernameInputField },
+  computed: {
+    ...mapGetters(['authGetStatus']),
+  },
   data: () => ({
     form: {
       username: '',
+      isInvalid: true,
     },
     loading: true,
   }),
   methods: {
+    onInput(username, isInvalid) {
+      this.form.username = username;
+      this.form.isInvalid = isInvalid;
+    },
     onSubmit(event) {
       event.preventDefault();
 
@@ -111,19 +108,6 @@ export default {
             );
           }
         });
-    },
-  },
-  computed: {
-    ...mapGetters(['authGetStatus']),
-  },
-  validations: {
-    form: {
-      username: {
-        required,
-        alphaNum,
-        minLength: minLength(8),
-        maxLength: maxLength(64),
-      },
     },
   },
 };

--- a/packages/frontend/src/views/Registration.vue
+++ b/packages/frontend/src/views/Registration.vue
@@ -9,18 +9,7 @@
     >
       <b-loading :is-full-page="false" :active="authGetStatus.pending"></b-loading>
 
-      <div class="field">
-        <div class="control">
-          <input
-            autofocus
-            id="username"
-            class="input is-large"
-            type="text"
-            v-model="form.username"
-            :placeholder="$t('views.registration.usernamePlaceholder')"
-          />
-        </div>
-      </div>
+      <username-input-field class="mb-3"></username-input-field>
 
       <div class="field">
         <div class="control">
@@ -51,17 +40,18 @@
 
 <script>
 import {
-  required, minLength, maxLength, alphaNum,
+  required, minLength, maxLength,
 } from 'vuelidate/lib/validators';
 import { startAttestation } from '@simplewebauthn/browser';
 import { mapGetters } from 'vuex';
 import { validate } from 'uuid';
 import { notifyFailure, notifySuccess } from '../notification';
 import AuthenticationLayout from '../layouts/AuthenticationLayout.vue';
+import UsernameInputField from '../components/UsernameInputField.vue';
 
 export default {
   name: 'RegistrationView',
-  components: { AuthenticationLayout },
+  components: { AuthenticationLayout, UsernameInputField },
   data: () => ({
     form: {
       username: '',
@@ -79,6 +69,12 @@ export default {
     this.form.token = token;
   },
   methods: {
+
+    onUsernameInput(username, isInvalid) {
+      this.form.username = username;
+      this.isInvalid = isInvalid;
+    },
+
     onSubmit(event) {
       event.preventDefault();
 
@@ -148,12 +144,6 @@ export default {
   },
   validations: {
     form: {
-      username: {
-        required,
-        alphaNum,
-        minLength: minLength(8),
-        maxLength: maxLength(64),
-      },
       token: {
         required,
         minLength: minLength(36),

--- a/packages/frontend/src/views/Registration.vue
+++ b/packages/frontend/src/views/Registration.vue
@@ -28,7 +28,7 @@
           <button
             id="registrationSubmitButton"
             class="button is-block is-primary is-large is-fullwidth is-marginless"
-            :disabled="$v.$invalid"
+            :disabled="this.$v.$invalid || this.isInvalid"
           >
             {{ $t('views.registration.registrationSubmitButton') }}
           </button>
@@ -57,6 +57,7 @@ export default {
       username: '',
       token: '',
     },
+    isInvalid: false,
   }),
   mounted() {
     // Check if token parameter is available

--- a/packages/frontend/tests/unit/views/login.view.spec.js
+++ b/packages/frontend/tests/unit/views/login.view.spec.js
@@ -18,7 +18,6 @@ describe('Login.view', () => {
   let actions;
   let store;
 
-  let usernameInput;
   let submitButton;
 
   beforeEach(() => {
@@ -40,8 +39,6 @@ describe('Login.view', () => {
     });
 
     wrapper = shallowMount(Login, { i18n, store, localVue });
-
-    usernameInput = wrapper.find('#username');
     submitButton = wrapper.find('#loginSubmitButton');
   });
 
@@ -49,59 +46,9 @@ describe('Login.view', () => {
     expect(wrapper.find(AuthenticationLayout).exists()).is.true;
   });
 
-  it('should render username input correctly', () => {
-    const testUserName = 'testusername';
-
-    expect(usernameInput.element.placeholder).to.be.equal(i18n.t('views.login.usernamePlaceholder'));
-    expect(usernameInput.element.type).to.be.equal('text');
-
-    usernameInput.setValue(testUserName);
-    expect(wrapper.vm.$data.form.username).to.be.equal(testUserName);
-  });
-
-  it('should change disabled submit button based on username input', async () => {
-    const tests = [
-      {
-        // required
-        prepare: () => { },
-        expect: true,
-      },
-      {
-        // minLength
-        prepare: () => {
-          usernameInput.setValue('a'.repeat(7));
-        },
-        expect: true,
-      },
-      {
-        // maxLength
-        prepare: () => {
-          usernameInput.setValue('a'.repeat(65));
-        },
-        expect: true,
-      },
-      {
-        // alphanum
-        prepare: () => {
-          usernameInput.setValue('test#123');
-        },
-        expect: true,
-      },
-      {
-        prepare: () => {
-          usernameInput.setValue('testuser123');
-        },
-        expect: false,
-      },
-    ];
-
-    for (let i = 0; i < tests.length; i++) {
-      const test = tests[i];
-
-      test.prepare();
-
-      await wrapper.vm.$nextTick();
-      expect(submitButton.element.disabled).to.equal(test.expect);
-    }
+  it('should disable submit button', async () => {
+    wrapper.vm.$data.form.isInvalid = true;
+    await wrapper.vm.$nextTick();
+    expect(submitButton.element.disabled).to.equal(true);
   });
 });

--- a/packages/frontend/tests/unit/views/registration.view.spec.js
+++ b/packages/frontend/tests/unit/views/registration.view.spec.js
@@ -19,7 +19,6 @@ describe('Registration.view', () => {
   let actions;
   let store;
 
-  let usernameInput;
   let tokenInput;
   let submitButton;
 
@@ -56,7 +55,6 @@ describe('Registration.view', () => {
       i18n, store, localVue, mocks,
     });
 
-    usernameInput = wrapper.find('#username');
     tokenInput = wrapper.find('#token');
     submitButton = wrapper.find('#registrationSubmitButton');
   });
@@ -65,67 +63,15 @@ describe('Registration.view', () => {
     expect(wrapper.find(AuthenticationLayout).exists()).is.true;
   });
 
-  it('should render username input correctly', () => {
-    const testUserName = 'testusername';
-
-    expect(usernameInput.element.placeholder).to.be.equal(i18n.t('views.registration.usernamePlaceholder'));
-    expect(usernameInput.element.type).to.be.equal('text');
-
-    usernameInput.setValue(testUserName);
-    expect(wrapper.vm.$data.form.username).to.be.equal(testUserName);
-  });
-
   it('should render token input correctly', () => {
     expect(tokenInput.element.placeholder).not.to.be.equal('');
     expect(tokenInput.element.type).to.be.equal('text');
   });
 
-  it('should change disabled submit button based on username input', async () => {
-    const tests = [
-      {
-        // required
-        prepare: () => { },
-        expect: true,
-      },
-      {
-        // minLength
-        prepare: () => {
-          usernameInput.setValue('a'.repeat(7));
-        },
-        expect: true,
-      },
-      {
-        // maxLength
-        prepare: () => {
-          usernameInput.setValue('a'.repeat(65));
-        },
-        expect: true,
-      },
-      {
-        // alphanum
-        prepare: () => {
-          usernameInput.setValue('test#123');
-        },
-        expect: true,
-      },
-      {
-        prepare: () => {
-          usernameInput.setValue('testuser123');
-        },
-        expect: false,
-      },
-    ];
-
-    tokenInput.setValue('109156be-c4fb-41ea-b1b4-efe1671c5836');
-
-    for (let i = 0; i < tests.length; i++) {
-      const test = tests[i];
-
-      test.prepare();
-
-      await wrapper.vm.$nextTick();
-      expect(submitButton.element.disabled).to.be.equal(test.expect);
-    }
+  it('should disable submit button', async () => {
+    wrapper.vm.$data.isInvalid = true;
+    await wrapper.vm.$nextTick();
+    expect(submitButton.element.disabled).to.equal(true);
   });
 
   it('should change disabled submit button based on token input', async () => {
@@ -157,8 +103,8 @@ describe('Registration.view', () => {
       },
     ];
 
+    wrapper.vm.$data.isInvalid = false;
     tokenInput.setValue('');
-    usernameInput.setValue('12345testuser');
 
     for (let i = 0; i < tests.length; i++) {
       const test = tests[i];


### PR DESCRIPTION
<!-- ⚠️ A pull request always needs a related issue! -->
> **As a** user
> **I want** see what chars are allowed
> **so that** I do not have try which char is wrong in my "f@ny:Us3_RN4<>E"

## Description
This PR fixes #165 #156. I have refactored the username input field to validate the submitted username in a central component. Now it is possible to use a valid Discord username from version 1, but only with ascii chars. I know that there are also non ascii discord usernames out there, but this feature is only to provide some backwards compatibility. 

### Screenshots
![grafik](https://user-images.githubusercontent.com/16938041/134810176-964ccaf1-e337-4552-90c1-530826cab5e0.png)
![grafik](https://user-images.githubusercontent.com/16938041/134810190-b0cd13a7-8c4a-4121-8e31-cd696cd88e90.png)
![grafik](https://user-images.githubusercontent.com/16938041/134810218-82d77625-7a2f-4ebf-8ddb-1d916bb469e2.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
<!--- Go over all the following points, and put an `x` in all boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- ~[ ] Make sure you are requesting to main. Don't request to release branch!~
- [X] I have linked the related issue.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
